### PR TITLE
fix: readded missing lines to mt7986a-bpi-r3-emmc.dts to

### DIFF
--- a/arch/arm/dts/mt7986a-bpi-r3-emmc.dts
+++ b/arch/arm/dts/mt7986a-bpi-r3-emmc.dts
@@ -8,6 +8,11 @@
 #include "mt7986a-bpi-r3-sd.dts"
 #include <dt-bindings/gpio/gpio.h>
 / {
+	compatible = "mediatek,mt7986", "mediatek,mt7986-rfb",
+		          "mediatek,mt7986-emmc-rfb";
+	bl2_verify {
+		bl2_compatible = "emmc";
+	};
 	reg_1p8v: regulator-1p8v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-1.8V";


### PR DESCRIPTION
address the following error when cold-booting from the emmc.

NOTICE:  BL2: v2.6(release):c30a1caf827-dirty emmc
NOTICE:  BL2: Built : 20:12:40, Feb  7 2024
NOTICE:  WDT: disabled
NOTICE:  CPU: MT7986 (2000MHz)
NOTICE:  EMI: Using DDR4 settings
NOTICE:  EMI: Detected DRAM size: 2048MB
NOTICE:  EMI: complex R/W mem test passed
ERROR:   MSDC: Command has timed out with cmd=8, arg=0x1aa
ERROR:   MSDC: Command has timed out with cmd=17, arg=0x680000
ERROR:   MSDC: Command has timed out with cmd=17, arg=0x680000
ERROR:   BL2: Failed to load image id 3 (-5)

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
